### PR TITLE
feat: HTTP server implementation

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,66 +1,72 @@
-import yargs from "yargs";
-import { hideBin } from "yargs/helpers";
-import { addNote, listNotes, readByTitle, removeFromList } from "./notes";
+import http from 'http';
+import { addNote, listNotes, readByTitle, removeFromList } from './notes';
 
-yargs(hideBin(process.argv))
-  .command({
-    command: "add",
-    describe: "Add a new note",
-    builder: {
-      title: {
-        describe: "Note title",
-        demandOption: true,
-        type: "string",
-      },
-      body: {
-        describe: "Note body",
-        demandOption: true,
-        type: "string",
-      },
-    },
-    handler(argv) {
-      if (typeof argv.title === "string" && typeof argv.body === "string") {
-        addNote(argv.title, argv.body);
+const getRequest=(req: http.IncomingMessage): Promise<any>=> {
+  return new Promise((resolve, reject) => {
+    let body='';
+    req.on('data', chunk => (body+=chunk));
+    req.on('end', ()=>{
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
       }
-    },
-  })
-  .command({
-    command: "list",
-    describe: "List all notes",
-    handler() {
-      listNotes();
-    },
-  })
-  .command({
-    command: "read",
-    describe: "Read a note by Title",
-    builder: {
-      title: {
-        describe: "Note title",
-        demandOption: true,
-        type: "string",
-      },
-    },
-    handler(argv) {
-      if (typeof argv.title === "string") {
-        readByTitle(argv.title);
-      }
-    },
-  })
-  .command({
-    command: "remove",
-    describe: "Remove note from list",
-    builder: {
-      title: {
-        describe: "Note title",
-        demandOption: true,
-        type: "string",
-      },
-    },
-    handler(argv) {
-      if (typeof argv.title === "string") {
-        removeFromList(argv.title);
-      }
-    },
-  })
-  .parse();
+    });
+  });
+};
+
+const server=http.createServer(async (req, res) => {
+  const url=req.url || '';
+  const method=req.method || '';
+  
+  if (method==='GET' && url==='/notes') {
+    const notes=listNotes();
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify(notes));
+    return;
+  }
+
+  if (method==='GET' && url.startsWith('/notes/')) {
+    const title=decodeURIComponent(url.split('/notes/')[1]);
+    const note=readByTitle(title);
+    if (note) {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify(note));
+    } else {
+      res.writeHead(404, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({message: 'Note not found'}));
+    }
+    return;
+  }
+  if (method==='POST' && url==='/notes') {
+    try {
+      const {title, body} =await getRequest(req);
+      addNote(title, body);
+      res.writeHead(201, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({message: 'Note added'}));
+    } catch (err) {
+      res.writeHead(400, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({message: 'Invalid JSON body'}));
+    }
+    return;
+  }
+
+  if (method==='DELETE' && url.startsWith('/notes/')) {
+    const title=decodeURIComponent(url.split('/notes/')[1]);
+    const success=removeFromList(title);
+    if (success) {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({ message: 'Note deleted' }));
+    } else {
+      res.writeHead(404, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({message: 'Note not found'}));
+    }
+    return;
+  }
+  res.writeHead(404, {'Content-Type': 'application/json'});
+  res.end(JSON.stringify({message: 'Route not found'}));
+});
+
+server.listen(3000, ()=>{
+  console.log('Server is running on http://localhost:3000');
+});

--- a/app.ts
+++ b/app.ts
@@ -6,94 +6,100 @@ import {
   removeFromList,
   updateNote,
 } from "./notes";
-
-const getRequest = (req: http.IncomingMessage): Promise<any> => {
-  return new Promise((resolve, reject) => {
-    let body = "";
-    req.on("data", (chunk) => (body += chunk));
-    req.on("end", () => {
-      try {
-        resolve(JSON.parse(body));
-      } catch (err) {
-        reject(err);
-      }
-    });
-  });
-};
+import { getRequest } from "./utils";
 
 const server = http.createServer(async (req, res) => {
   const url = req.url || "";
   const method = req.method || "";
 
-  if (method === "GET" && url === "/notes") {
-    const notes = listNotes();
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(notes));
-    return;
-  }
-
-  if (method === "GET" && url.startsWith("/notes/")) {
-    const title = decodeURIComponent(url.split("/notes/")[1]);
-    const note = readByTitle(title);
-    if (note) {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(note));
-    } else {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Note not found" }));
-    }
-    return;
-  }
-  if (method === "POST" && url === "/notes") {
-    try {
-      const { title, body } = await getRequest(req);
-      addNote(title, body);
-      res.writeHead(201, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Note added" }));
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Invalid JSON body" }));
-    }
-    return;
-  }
-
-  if (method === "PATCH" && url.startsWith("/notes/")) {
-    try {
-      const oldTitle = decodeURIComponent(url.split("/notes/")[1]);
-      const { title: newTitle, body: newBody } = await getRequest(req);
-      const updated = updateNote(oldTitle, newTitle, newBody);
-      if (updated) {
+  switch (method) {
+    case "GET":
+      if (url === "/notes") {
+        const notes = listNotes();
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ message: "Note updated successfully" }));
-        return;
+        res.end(JSON.stringify(notes));
+      } else if (url.startsWith("/notes/")) {
+        const title = decodeURIComponent(url.split("/notes/")[1]);
+        const note = readByTitle(title);
+        if (note) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(note));
+        } else {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ message: "Note not found" }));
+        }
       } else {
         res.writeHead(404, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ message: "Note not found" }));
-        return;
+        res.end(JSON.stringify({ message: "Route not found" }));
       }
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Invalid JSON or malformed request" }));
-      return;
-    }
-  }
+      break;
 
-  if (method === "DELETE" && url.startsWith("/notes/")) {
-    const title = decodeURIComponent(url.split("/notes/")[1]);
-    const success = removeFromList(title);
-    if (success) {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Note deleted" }));
-    } else {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ message: "Note not found" }));
-    }
-    return;
+    case "POST":
+      if (url === "/notes") {
+        try {
+          const { title, body } = await getRequest(req);
+          addNote(title, body);
+          res.writeHead(201, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ message: "Note added" }));
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ message: "Invalid JSON body" }));
+        }
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Route not found" }));
+      }
+      break;
+
+    case "PATCH":
+      if (url.startsWith("/notes/")) {
+        try {
+          const oldTitle = decodeURIComponent(url.split("/notes/")[1]);
+          const { title: newTitle, body: newBody } = await getRequest(req);
+          const updated = updateNote(oldTitle, newTitle, newBody);
+          if (updated) {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ message: "Note updated successfully" }));
+          } else {
+            res.writeHead(404, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ message: "Note not found" }));
+          }
+        } catch {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({ message: "Invalid JSON or malformed request" })
+          );
+        }
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Route not found" }));
+      }
+      break;
+
+    case "DELETE":
+      if (url.startsWith("/notes/")) {
+        const title = decodeURIComponent(url.split("/notes/")[1]);
+        const success = removeFromList(title);
+        if (success) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ message: "Note deleted" }));
+        } else {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ message: "Note not found" }));
+        }
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Route not found" }));
+      }
+      break;
+
+    default:
+      res.writeHead(405, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Method not allowed" }));
+      break;
   }
-  res.writeHead(404, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ message: "Route not found" }));
 });
 
-server.listen(3000, () => {
-  console.log("Server is running on http://localhost:3000");
+server.listen(5000, () => {
+  console.log("Server is running on http://localhost:5000");
 });

--- a/app.ts
+++ b/app.ts
@@ -1,11 +1,17 @@
-import http from 'http';
-import { addNote, listNotes, readByTitle, removeFromList } from './notes';
+import http from "http";
+import {
+  addNote,
+  listNotes,
+  readByTitle,
+  removeFromList,
+  updateNote,
+} from "./notes";
 
-const getRequest=(req: http.IncomingMessage): Promise<any>=> {
+const getRequest = (req: http.IncomingMessage): Promise<any> => {
   return new Promise((resolve, reject) => {
-    let body='';
-    req.on('data', chunk => (body+=chunk));
-    req.on('end', ()=>{
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
       try {
         resolve(JSON.parse(body));
       } catch (err) {
@@ -15,58 +21,79 @@ const getRequest=(req: http.IncomingMessage): Promise<any>=> {
   });
 };
 
-const server=http.createServer(async (req, res) => {
-  const url=req.url || '';
-  const method=req.method || '';
-  
-  if (method==='GET' && url==='/notes') {
-    const notes=listNotes();
-    res.writeHead(200, {'Content-Type': 'application/json'});
+const server = http.createServer(async (req, res) => {
+  const url = req.url || "";
+  const method = req.method || "";
+
+  if (method === "GET" && url === "/notes") {
+    const notes = listNotes();
+    res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(notes));
     return;
   }
 
-  if (method==='GET' && url.startsWith('/notes/')) {
-    const title=decodeURIComponent(url.split('/notes/')[1]);
-    const note=readByTitle(title);
+  if (method === "GET" && url.startsWith("/notes/")) {
+    const title = decodeURIComponent(url.split("/notes/")[1]);
+    const note = readByTitle(title);
     if (note) {
-      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(note));
     } else {
-      res.writeHead(404, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({message: 'Note not found'}));
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Note not found" }));
     }
     return;
   }
-  if (method==='POST' && url==='/notes') {
+  if (method === "POST" && url === "/notes") {
     try {
-      const {title, body} =await getRequest(req);
+      const { title, body } = await getRequest(req);
       addNote(title, body);
-      res.writeHead(201, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({message: 'Note added'}));
+      res.writeHead(201, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Note added" }));
     } catch (err) {
-      res.writeHead(400, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({message: 'Invalid JSON body'}));
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Invalid JSON body" }));
     }
     return;
   }
 
-  if (method==='DELETE' && url.startsWith('/notes/')) {
-    const title=decodeURIComponent(url.split('/notes/')[1]);
-    const success=removeFromList(title);
+  if (method === "PATCH" && url.startsWith("/notes/")) {
+    try {
+      const oldTitle = decodeURIComponent(url.split("/notes/")[1]);
+      const { title: newTitle, body: newBody } = await getRequest(req);
+      const updated = updateNote(oldTitle, newTitle, newBody);
+      if (updated) {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Note updated successfully" }));
+        return;
+      } else {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ message: "Note not found" }));
+        return;
+      }
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Invalid JSON or malformed request" }));
+      return;
+    }
+  }
+
+  if (method === "DELETE" && url.startsWith("/notes/")) {
+    const title = decodeURIComponent(url.split("/notes/")[1]);
+    const success = removeFromList(title);
     if (success) {
-      res.writeHead(200, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({ message: 'Note deleted' }));
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Note deleted" }));
     } else {
-      res.writeHead(404, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({message: 'Note not found'}));
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ message: "Note not found" }));
     }
     return;
   }
-  res.writeHead(404, {'Content-Type': 'application/json'});
-  res.end(JSON.stringify({message: 'Route not found'}));
+  res.writeHead(404, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ message: "Route not found" }));
 });
 
-server.listen(3000, ()=>{
-  console.log('Server is running on http://localhost:3000');
+server.listen(3000, () => {
+  console.log("Server is running on http://localhost:3000");
 });

--- a/data/notes.json
+++ b/data/notes.json
@@ -2,5 +2,9 @@
   {
     "title": "Goals",
     "body": "Finish the TypeScript project"
+  },
+  {
+    "title": "Homwork",
+    "body": "Finish projec"
   }
 ]

--- a/data/notes.json
+++ b/data/notes.json
@@ -6,5 +6,9 @@
   {
     "title": "Homwork",
     "body": "Finish projec"
+  },
+  {
+    "title": "Hello",
+    "body": "This is a note from Postman"
   }
 ]

--- a/notes.ts
+++ b/notes.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import chalk from "chalk";
+const notesFile = "notes.json";
 
 const notesFilePath = path.join(__dirname, "data", "notes.json");
 interface Note {
@@ -70,5 +71,24 @@ export function removeFromList(title: string): boolean {
   }
   saveNotes(note);
   console.log(chalk.green("Note removed."));
+  return true;
+}
+
+export function updateNote(
+  title: string,
+  newTitle?: string,
+  newBody?: string
+): boolean {
+  const notes = loadNotes();
+
+  const noteIndex = notes.findIndex(
+    (note) => note.title.toLowerCase() === title.toLowerCase()
+  );
+  if (noteIndex === -1) return false;
+
+  if (newTitle) notes[noteIndex].title = capitalizeFirst(newTitle.trim());
+  if (newBody) notes[noteIndex].body = capitalizeFirst(newBody.trim());
+
+  saveNotes(notes);
   return true;
 }

--- a/notes.ts
+++ b/notes.ts
@@ -1,7 +1,6 @@
 import fs from "fs";
 import path from "path";
 import chalk from "chalk";
-const notesFile = "notes.json";
 
 const notesFilePath = path.join(__dirname, "data", "notes.json");
 interface Note {
@@ -52,13 +51,6 @@ export function readByTitle(title: string): Note | undefined {
   const notes = loadNotes();
   const lowercase = title.toLowerCase();
   return notes.find((note) => note.title.toLowerCase() === lowercase);
-  /*if (!note) {
-    console.log(chalk.red("Note not found"));
-    return;
-  }
-  console.log(chalk.green("Note(s) found: "));
-  console.log(chalk.yellow(note.title));
-  console.log(chalk.white(`   ${note.body}`));*/
 }
 
 export function removeFromList(title: string): boolean {
@@ -80,15 +72,12 @@ export function updateNote(
   newBody?: string
 ): boolean {
   const notes = loadNotes();
-
   const noteIndex = notes.findIndex(
     (note) => note.title.toLowerCase() === title.toLowerCase()
   );
   if (noteIndex === -1) return false;
-
   if (newTitle) notes[noteIndex].title = capitalizeFirst(newTitle.trim());
   if (newBody) notes[noteIndex].body = capitalizeFirst(newBody.trim());
-
   saveNotes(notes);
   return true;
 }

--- a/notes.ts
+++ b/notes.ts
@@ -43,40 +43,32 @@ export function addNote(title: string, body: string): void {
   console.log(chalk.green("Note added"));
 }
 
-export function listNotes(): void {
-  const notes = loadNotes();
-  if (notes.length === 0) {
-    console.log(chalk.red("No notes found."));
-    return;
-  }
-  console.log(chalk.green("Your notes: "));
-  notes.forEach((note, index) => {
-    console.log(chalk.yellow(`${index + 1}. ${note.title}`));
-    console.log(chalk.white(`   ${note.body}`));
-  });
+export function listNotes(): Note[] {
+  return loadNotes();
 }
 
-export function readByTitle(title: string): void {
+export function readByTitle(title: string): Note | undefined {
   const notes = loadNotes();
   const lowercase = title.toLowerCase();
-  const note = notes.find((note) => note.title.toLowerCase() === lowercase);
-  if (!note) {
+  return notes.find((note) => note.title.toLowerCase() === lowercase);
+  /*if (!note) {
     console.log(chalk.red("Note not found"));
     return;
   }
   console.log(chalk.green("Note(s) found: "));
   console.log(chalk.yellow(note.title));
-  console.log(chalk.white(`   ${note.body}`));
+  console.log(chalk.white(`   ${note.body}`));*/
 }
 
-export function removeFromList(title: string): void {
+export function removeFromList(title: string): boolean {
   const notes = loadNotes();
   const lowercase = title.toLowerCase();
   const note = notes.filter((note) => note.title.toLowerCase() !== lowercase);
   if (note.length === notes.length) {
     console.log(chalk.red("Note doesn't exist."));
-    return;
+    return false;
   }
   saveNotes(note);
   console.log(chalk.green("Note removed."));
+  return true;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,81 @@
         "@types/node": "^24.0.0",
         "@types/yargs": "^17.0.33",
         "chalk": "^5.4.1",
-        "typescript": "^5.8.3",
         "yargs": "^17.7.2"
+      },
+      "devDependencies": {
+        "ts-node": "^10.9.2",
+        "typescript": "^5.8.3"
       }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "24.0.0",
@@ -40,6 +112,32 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
+    "node_modules/acorn": {
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -63,6 +161,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "5.4.1",
@@ -108,6 +213,23 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -140,6 +262,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -176,10 +305,55 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -193,6 +367,13 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi": {
@@ -246,6 +427,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "ts-node app.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "@types/node": "^24.0.0",
     "@types/yargs": "^17.0.33",
     "chalk": "^5.4.1",
-    "typescript": "^5.8.3",
     "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.8.3"
   }
 }

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,15 @@
+import http from "http";
+
+export const getRequest = (req: http.IncomingMessage): Promise<any> => {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    req.on("data", (chunk) => (body += chunk));
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+};


### PR DESCRIPTION
This PR implements an HTTP server for the notes CLI application. It handles the following RESTful routes:

- `GET /notes`: Returns all notes as JSON
- `GET /notes/:title`: Returns a specific note by title
- `POST /notes`: Creates a new note from JSON body
- `DELETE /notes/:title`: Deletes a note by title
- `PATCH /notes/:title`: Updates a note's title and/or body